### PR TITLE
[fix] ffmpeg 6.1 バージョンアップ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
-# FFmpeg 6.0 をインストール
+# FFmpeg 6.1 をインストール
 RUN curl -LO \
-    https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz && \
-    tar -xvf ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz && \
-    cp -ar ffmpeg-n6.0-latest-linux64-gpl-shared-6.0/bin/* /usr/bin/ && \
-    cp -ar ffmpeg-n6.0-latest-linux64-gpl-shared-6.0/lib/* /usr/lib/ && \
-    rm -rf ffmpeg-n6.0-latest-linux64-gpl-shared-6.0 && \
-    rm -rf ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz
+    https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.1-latest-linux64-gpl-shared-6.1.tar.xz && \
+    tar -xvf ffmpeg-n6.1-latest-linux64-gpl-shared-6.1.tar.xz && \
+    cp -ar ffmpeg-n6.1-latest-linux64-gpl-shared-6.1/bin/* /usr/bin/ && \
+    cp -ar ffmpeg-n6.1-latest-linux64-gpl-shared-6.1/lib/* /usr/lib/ && \
+    rm -rf ffmpeg-n6.1-latest-linux64-gpl-shared-6.1 && \
+    rm -rf ffmpeg-n6.1-latest-linux64-gpl-shared-6.1.tar.xz
 
 # コンテナ内での作業ディレクトリを指定
 WORKDIR /code/


### PR DESCRIPTION
ffmpeg 6.1 がリリースされており、[BtbN/FFmpeg-Builds](
https://github.com/BtbN/FFmpeg-Builds/releases/tag/latest) には 6.0 がビルドしなくなりました。